### PR TITLE
Overwrote shouldComponentUpdate method in Gif and Searchbar

### DIFF
--- a/src/components/gif.jsx
+++ b/src/components/gif.jsx
@@ -6,6 +6,10 @@ class Gif extends Component {
     selectFunction(event.target.id);
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return nextProps.id !== this.props.id;
+  }
+
   render() {
     const { id } = this.props;
     const src = `https://media1.giphy.com/media/${id}/giphy.gif`;

--- a/src/components/searchbar.jsx
+++ b/src/components/searchbar.jsx
@@ -6,6 +6,10 @@ class Searchbar extends Component {
     searchFunction(event.target.value);
   }
 
+  shouldComponentUpdate() {
+    return false;
+  }
+
   render() {
     return (
       <input


### PR DESCRIPTION
to optimize the rendering in both Gif and Searchbar, the shouldComponentUpdate method was overwritten: 

=> Searchbar will never rerender as the textinput is render by the browser
=> Gif will only render when the id is changing